### PR TITLE
Fix vps fail2ban config and hoist setup.sh strict mode

### DIFF
--- a/vps/configs/README.md
+++ b/vps/configs/README.md
@@ -35,10 +35,13 @@ Automatic security updates (unattended-upgrades) are configured via a drop-in at
 ### Fail2ban (`fail2ban/`)
 - **jail.local.template**: Main jail configuration for SSH and Traefik services
   - Placeholder: `{{SSH_PORT}}` - Custom SSH port
+  - `backend = auto` so each jail's `logpath` is honored (a `systemd` backend would ignore them and miss Traefik/recidive logs)
+  - `action = %(action_)s` (plain ban, no email) — switch to `%(action_mwl)s` only after installing and configuring an MTA
+  - `[sshd]` uses `filter = sshd[mode=aggressive]` to catch pre-auth disconnect patterns the default mode misses (replaces the deprecated `[sshd-ddos]` jail, which no longer ships in fail2ban 1.x)
 - **filters/**: Custom Traefik-specific filters
   - `traefik-auth.conf`: Detects authentication failures (401/403)
   - `traefik-ratelimit.conf`: Detects rate limiting (429)
-  - `traefik-badbots.conf`: Detects malicious bots and vulnerability scanners
+  - `traefik-badbots.conf`: Detects offensive security tools (nikto, sqlmap, nmap, etc.) and known scanner paths (`/.git`, `/.env`, `/wp-admin`, ...). Legitimate search-engine crawlers (Googlebot, bingbot, etc.) are NOT in this list — banning them tanks SEO.
 
 ### SSH
 

--- a/vps/configs/fail2ban/filters/traefik-badbots.conf
+++ b/vps/configs/fail2ban/filters/traefik-badbots.conf
@@ -1,6 +1,6 @@
 # Fail2Ban filter for Traefik bad bots and scanners
 [Definition]
-badbots = (?:nikto|sqlmap|fimap|nessus|whatweb|openvas|jorgee|masscan|zgrab|nmap|w3af|skipfish|arachni|wpscan|joomscan|dirbuster|gobuster|feroxbuster|wfuzz|hydra|medusa|brutus|havij|acunetix|netsparker|appscan|burpcollaborator|qualys|rapid7|metasploit|ZmEu|libwww-perl|python-requests|curl|wget)
+badbots = (?:nikto|sqlmap|fimap|nessus|whatweb|openvas|jorgee|masscan|zgrab|nmap|w3af|skipfish|arachni|wpscan|joomscan|dirbuster|gobuster|feroxbuster|wfuzz|hydra|medusa|havij|acunetix|netsparker|appscan|metasploit|nuclei|httpx|ZmEu|libwww-perl|python-requests|Go-http-client|curl|wget)
 failregex = ^<HOST> \- \S+ \[.*\] "(?:GET|POST|HEAD) [^"]+" [0-9]{3} [0-9]+ "[^"]*" "(?i)(?:%(badbots)s)[^"]*"$
             ^<HOST> \- \S+ \[.*\] "(?:GET|POST|HEAD) (?:/\.git|/\.env|/wp-admin|/phpMyAdmin|/phpmyadmin|/pma|/admin|/\.aws|/config\.json|/\.svn|/\.hg)[^"]*" [0-9]{3}
 ignoreregex =

--- a/vps/configs/fail2ban/filters/traefik-badbots.conf
+++ b/vps/configs/fail2ban/filters/traefik-badbots.conf
@@ -1,6 +1,6 @@
 # Fail2Ban filter for Traefik bad bots and scanners
 [Definition]
-badbots = Googlebot|bingbot|Baiduspider|yandex|facebookexternalhit|twitterbot|rogerbot|linkedinbot|embedly|quora link preview|showyoubot|outbrain|pinterest|slackbot|vkShare|W3C_Validator|whatsapp|Mediatoolkitbot|ahrefsbot|semrushbot|dotbot|applebot|duckduckbot
+badbots = (?:nikto|sqlmap|fimap|nessus|whatweb|openvas|jorgee|masscan|zgrab|nmap|w3af|skipfish|arachni|wpscan|joomscan|dirbuster|gobuster|feroxbuster|wfuzz|hydra|medusa|brutus|havij|acunetix|netsparker|appscan|burpcollaborator|qualys|rapid7|metasploit|ZmEu|libwww-perl|python-requests|curl|wget)
 failregex = ^<HOST> \- \S+ \[.*\] "(?:GET|POST|HEAD) [^"]+" [0-9]{3} [0-9]+ "[^"]*" "(?i)(?:%(badbots)s)[^"]*"$
             ^<HOST> \- \S+ \[.*\] "(?:GET|POST|HEAD) (?:/\.git|/\.env|/wp-admin|/phpMyAdmin|/phpmyadmin|/pma|/admin|/\.aws|/config\.json|/\.svn|/\.hg)[^"]*" [0-9]{3}
 ignoreregex =

--- a/vps/configs/fail2ban/jail.local.template
+++ b/vps/configs/fail2ban/jail.local.template
@@ -5,33 +5,29 @@ findtime = 600
 maxretry = 3
 destemail = root@localhost
 sendername = Fail2Ban
-action = %(action_mwl)s
+# Use plain ban action — %(action_mwl)s would require a working MTA (postfix/sendmail),
+# which this setup does not install. Status is visible via `fail2ban-client status <jail>`.
+action = %(action_)s
 
-# Backend
-backend = systemd
+# Backend — `auto` honors the `logpath` directives below. `systemd` would ignore
+# them and only watch journald, which doesn't carry Traefik or fail2ban's own log.
+backend = auto
 
 [sshd]
 enabled = true
 port = {{SSH_PORT}}
 filter = sshd
+# Aggressive mode catches more pre-auth disconnect / scan patterns that the
+# default filter misses. Replaces the deprecated [sshd-ddos] jail.
+mode = aggressive
 logpath = /var/log/auth.log
 maxretry = 3
 bantime = 3600
-
-[sshd-ddos]
-enabled = true
-port = {{SSH_PORT}}
-filter = sshd-ddos
-logpath = /var/log/auth.log
-maxretry = 10
-findtime = 60
-bantime = 600
 
 [recidive]
 enabled = true
 filter = recidive
 logpath = /var/log/fail2ban.log
-action = %(action_mwl)s
 bantime = 86400
 findtime = 86400
 maxretry = 2

--- a/vps/configs/fail2ban/jail.local.template
+++ b/vps/configs/fail2ban/jail.local.template
@@ -3,6 +3,7 @@
 bantime = 3600
 findtime = 600
 maxretry = 3
+# destemail/sendername unused with action_ — kept for future MTA enablement
 destemail = root@localhost
 sendername = Fail2Ban
 # Use plain ban action — %(action_mwl)s would require a working MTA (postfix/sendmail),

--- a/vps/configs/fail2ban/jail.local.template
+++ b/vps/configs/fail2ban/jail.local.template
@@ -16,10 +16,9 @@ backend = auto
 [sshd]
 enabled = true
 port = {{SSH_PORT}}
-filter = sshd
-# Aggressive mode catches more pre-auth disconnect / scan patterns that the
-# default filter misses. Replaces the deprecated [sshd-ddos] jail.
-mode = aggressive
+# Aggressive filter mode catches more pre-auth disconnect / scan patterns that
+# the default filter misses. Replaces the deprecated [sshd-ddos] jail.
+filter = sshd[mode=aggressive]
 logpath = /var/log/auth.log
 maxretry = 3
 bantime = 3600

--- a/vps/setup.sh
+++ b/vps/setup.sh
@@ -1,12 +1,8 @@
 #!/bin/bash
 
-# Start with basic error handling
-set -u
-
-# Enable full strict mode after initialization
-enable_strict_mode() {
-    set -euo pipefail
-}
+# Strict mode enabled up front so the ERR trap (set below) fires for any failure
+# during initialization — checks, logging setup, backup creation, etc.
+set -euo pipefail
 
 # VPS Ubuntu 24.04 Setup Script
 # Enhanced with security hardening, interactive configuration, and best practices
@@ -885,9 +881,6 @@ main() {
 
     # Interactive configuration
     interactive_config
-
-    # Enable strict mode after initialization
-    enable_strict_mode
 
     # System setup
     configure_timezone


### PR DESCRIPTION
## Summary

Fixes four real bugs in `vps/` discovered during a code review of the setup script and configs:

- **traefik-badbots filter** banned legitimate search-engine crawlers (Googlebot, bingbot, applebot, linkedinbot, slackbot, etc.) — would tank SEO and break link previews. Replaced with offensive-security tools (nikto, sqlmap, nuclei, httpx, etc.) and aggressive scripted clients (curl, wget, python-requests, Go-http-client).
- **jail.local.template** had `backend = systemd`, which silently ignores every `logpath` directive — broke the Traefik jails and `[recidive]` (none of those services log to journald). Switched to `backend = auto`.
- **`[sshd-ddos]` jail** was enabled, but its filter no longer ships in fail2ban 1.x (Ubuntu 24.04 has 1.0.2). Dropped, and added `filter = sshd[mode=aggressive]` to `[sshd]` to recover the pre-auth disconnect / scan patterns it used to catch.
- **`action = %(action_mwl)s`** required a working MTA we don't install — fail2ban would have spammed errors trying to send mail. Switched to `%(action_)s` (plain ban). `destemail`/`sendername` left in place with a comment explaining they're parked for future MTA enablement.
- **`enable_strict_mode`** in `setup.sh` was called only after pre-flight checks, logging setup, backup creation, and the interactive prompts — meaning the ERR trap could miss failures during initialization. Hoisted `set -euo pipefail` to the top of the script.

Plus a `vps/configs/README.md` update documenting the choices.

## Commits

```
f0dfdd1 docs(vps): note destemail/sendername are dead settings
95450ec fix(vps): refine traefik-badbots curation
0767c02 docs(vps): document fail2ban config choices
9321b23 fix(vps): enable strict mode at script start
333b09f fix(vps): use canonical filter-init syntax for sshd aggressive mode
e244803 fix(vps): repair fail2ban jail config
be24c6d fix(vps): stop banning legitimate crawlers in traefik-badbots filter
```

## Test plan

Run on a server (Ubuntu 24.04) after re-running `vps/setup.sh` or manually copying the updated configs into place:

- [ ] Validate the rendered fail2ban config — should print nothing on success
  ```bash
  sudo fail2ban-client -t
  ```
- [ ] Confirm aggressive mode actually loaded for sshd
  ```bash
  sudo fail2ban-client -d 2>&1 | grep -A3 "'sshd'.*'failregex'"
  ```
  Expect a regex set that includes `Did not receive identification` / `Connection (closed|reset) by .* preauth` patterns. If only normal-mode patterns appear, the `[mode=aggressive]` propagation didn't take.
- [ ] Confirm all expected jails are running (no `sshd-ddos`)
  ```bash
  sudo fail2ban-client status
  ```
  Expect: `sshd`, `recidive`, `traefik-auth`, `traefik-ratelimit`, `traefik-badbots`.
- [ ] Tail fail2ban log for any startup errors (MTA complaints, missing filters)
  ```bash
  sudo journalctl -u fail2ban -n 50 --no-pager
  ```
- [ ] (If running fresh on a new host) Run `vps/setup.sh` end-to-end and confirm it errors out early on any pre-flight failure (proves the strict-mode hoist works) instead of marching forward.