### PR TITLE
Add tmux theme switching: catppuccin (default) + rose-pine

### DIFF
--- a/tmux/.tmux.conf
+++ b/tmux/.tmux.conf
@@ -58,21 +58,13 @@ bind -n S-Left  previous-window
 bind -n S-Right next-window
 
 # Reload tmux config
-bind r source-file ~/.tmux.conf
+bind r source-file ~/.tmux.conf \; display-message "tmux.conf reloaded"
 
 ###############
 # Look and Feel
 ###############
 # status bar
 set-option -g status-position top
-
-# Set window/pane colors and add "padding" around panes and windows
-# setw -g window-style 'bg=#121212'
-setw -g window-active-style 'bg=#102843'
-
-# pane color option
-set -g pane-border-style fg=black
-# set -g pane-active-border-style fg=blue
 
 # Use vim keybindings in copy mode
 setw -g mode-keys vi
@@ -98,42 +90,29 @@ bind C-n next-window
 # tmux list-keys -t vi-copy
 #
 
-# TMUX Plugin Manager Configuration
-# prefix + I - To Install Plugins
-# prefix + U - To update plugins
-# prefix + alt + u - Uninstall unused plugins
+# TMUX Plugin Manager
+# prefix + I - install plugins
+# prefix + U - update plugins
+# prefix + alt + u - uninstall unused plugins
 
-set -g @tpm_plugins '                     \
-    catppuccin/tmux#v2.1.3 \
-    nhdaly/tmux-better-mouse-mode \
-    tmux-plugins/tmux-pain-control        \
-    tmux-plugins/tmux-prefix-highlight    \
-    tmux-plugins/tmux-sensible            \
-    tmux-plugins/tmux-yank                \
-    '
+set -g @plugin 'tmux-plugins/tpm'
+set -g @plugin 'nhdaly/tmux-better-mouse-mode'
+set -g @plugin 'tmux-plugins/tmux-pain-control'
+set -g @plugin 'tmux-plugins/tmux-prefix-highlight'
+set -g @plugin 'tmux-plugins/tmux-sensible'
+set -g @plugin 'tmux-plugins/tmux-yank'
 
-#  catppuccin themes latte, frappe, macchiato or mocha
-set -g @catppuccin_flavor 'macchiato'
-
-# Window styling
-set -g @catppuccin_window_status_style "rounded"
-set -g @catppuccin_window_text " #W"
-set -g @catppuccin_window_current_text " #W"
-set -g @catppuccin_window_flags "icon"
-set -g @catppuccin_window_number_position "left"
-
-# Date/time format
-set -g @catppuccin_date_time_text " %a %b %d  %H:%M"
-
-# Status bar
-set -g status-left ""
-set -g status-right-length 100
-set -gF status-right "#{E:@catppuccin_status_directory}#{E:@catppuccin_status_session}#{E:@catppuccin_status_date_time}"
+# Theme — uncomment exactly one
+source-file ~/.tmux/themes/catppuccin-macchiato.conf
+# source-file ~/.tmux/themes/rose-pine-dawn.conf
 
 set-environment -g TMUX_PLUGIN_MANAGER_PATH "~/.tmux/plugins/"
-# === !! Auto-install tpm  if it hasn't been installed already !! ===
-if-shell "test ! -d ~/.tmux/plugins/tpm" \
-   "run-shell 'git clone https://github.com/tmux-plugins/tpm ~/.tmux/plugins/tpm && ~/.tmux/plugins/tpm/bin/install_plugins'"
+
+# Auto-install TPM if missing
+if "test ! -d ~/.tmux/plugins/tpm" {
+  display-message "Installing tpm..."
+  run "git clone --depth 1 https://github.com/tmux-plugins/tpm ~/.tmux/plugins/tpm && ~/.tmux/plugins/tpm/bin/install_plugins"
+}
 
 # Local config
 if-shell "[ -f ~/.tmux.conf.local ]" 'source ~/.tmux.conf.local'
@@ -141,5 +120,3 @@ if-shell "[ -f ~/.tmux.conf.local ]" 'source ~/.tmux.conf.local'
 # Initializes TMUX plugin manager.
 # Keep this line at the very bottom of tmux.conf.
 run '~/.tmux/plugins/tpm/tpm'
-
-bind-key -T root S-Enter send-keys Escape "[13;2u"

--- a/tmux/.tmux/themes/catppuccin-macchiato.conf
+++ b/tmux/.tmux/themes/catppuccin-macchiato.conf
@@ -1,0 +1,21 @@
+# Catppuccin (macchiato)
+# https://github.com/catppuccin/tmux
+set -g @plugin 'catppuccin/tmux#v2.1.3'
+
+# Flavor: latte, frappe, macchiato, mocha
+set -g @catppuccin_flavor 'macchiato'
+
+# Window styling
+set -g @catppuccin_window_status_style "rounded"
+set -g @catppuccin_window_text " #W"
+set -g @catppuccin_window_current_text " #W"
+set -g @catppuccin_window_flags "icon"
+set -g @catppuccin_window_number_position "left"
+
+# Date/time format
+set -g @catppuccin_date_time_text " %a %b %d  %H:%M"
+
+# Status bar
+set -g status-left ""
+set -g status-right-length 100
+set -gF status-right "#{E:@catppuccin_status_directory}#{E:@catppuccin_status_session}#{E:@catppuccin_status_date_time}"

--- a/tmux/.tmux/themes/rose-pine-dawn.conf
+++ b/tmux/.tmux/themes/rose-pine-dawn.conf
@@ -1,0 +1,19 @@
+# Rosé Pine (dawn)
+# https://github.com/rose-pine/tmux
+set -g @plugin 'rose-pine/tmux'
+
+# Variant: main, moon, dawn
+set -g @rose_pine_variant 'dawn'
+
+# Status content
+set -g @rose_pine_host 'on'
+set -g @rose_pine_user 'on'
+set -g @rose_pine_directory 'on'
+set -g @rose_pine_date_time '%a %b %d  %H:%M'
+
+# Use current window's program in the window list
+set -g @rose_pine_show_current_program 'on'
+set -g @rose_pine_show_pane_directory 'on'
+
+# Reset status-left so the plugin owns the bar (catppuccin leaves it set on reload)
+set -g status-left ""


### PR DESCRIPTION
## Summary
- Move the catppuccin block out of `.tmux.conf` and into `tmux/.tmux/themes/catppuccin-macchiato.conf`; add `tmux/.tmux/themes/rose-pine-dawn.conf` so themes can be swapped by uncommenting one `source-file` line.
- Migrate the deprecated `@tpm_plugins` block to per-line `@plugin` declarations (TPM's recommended syntax).
- Remove `window-active-style 'bg=#102843'` and `pane-border-style fg=black` — both were fighting with catppuccin's colors (the former was the most likely reason the theme "looked off" on the active pane).
- Drop the manual `S-Enter` CSI-u binding; `extended-keys on` + `terminal-features ',*:extkeys'` already handle it natively on tmux 3.2+.
- Small polish: reload feedback on `prefix + r`, modern `if { ... }` block + `display-message` + `--depth 1` shallow clone in the TPM auto-installer.

## Test plan
- [ ] Pull the branch, run `stow -R tmux` from the dotfiles dir so `~/.tmux/themes/` exists.
- [ ] Start a fresh tmux session: catppuccin macchiato renders (status bar + active pane look correct, no navy override).
- [ ] `prefix + r` shows "tmux.conf reloaded" in the status line.
- [ ] In `.tmux.conf`, comment the catppuccin `source-file` line and uncomment the rose-pine one. `prefix + I` to install rose-pine. `tmux kill-server` then start fresh — rose-pine dawn renders.
- [ ] Confirm `Shift+Enter` still does whatever it did before in your Neovim/etc. setup (it should — tmux passes it through via extkeys).
- [ ] Confirm synchronized panes still toggles with `prefix + y`.

## Notes
- Two theme plugins coexist in `~/.tmux/plugins/`; only the actively sourced one is loaded. Harmless extra disk use.
- If you swap rose-pine → catppuccin (or back) without restarting tmux, stale `status-right` from the previous theme may linger. `tmux kill-server` is the clean reset.