### PR TITLE
Add ntfy.sh hooks for remote Claude session notifications

### DIFF
--- a/claude/.claude/hooks/notify-ntfy.sh
+++ b/claude/.claude/hooks/notify-ntfy.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Forward Claude Code hook events to ntfy.sh.
+# Topic comes from $NTFY_CLAUDE_TOPIC (set in ~/.zshrc.local, gitignored).
+# No-ops silently if unset. Reads hook payload JSON from stdin.
+
+set -u
+
+topic="${NTFY_CLAUDE_TOPIC:-}"
+[ -z "$topic" ] && exit 0
+
+payload="$(cat)"
+
+extract() {
+  printf '%s' "$payload" | jq -r --arg k "$1" '.[$k] // empty'
+}
+
+event=$(extract hook_event_name)
+message=$(extract message)
+cwd=$(extract cwd)
+
+project=$(basename "${cwd:-claude}")
+host=$(hostname -s 2>/dev/null || echo claude)
+
+case "$event" in
+  Notification)
+    title="Claude waiting · $host · $project"
+    body="${message:-Waiting for input}"
+    tags="bell"
+    priority="4"
+    ;;
+  Stop)
+    title="Claude done · $host · $project"
+    body="Turn complete"
+    tags="heavy_check_mark"
+    priority="2"
+    ;;
+  *)
+    title="Claude · $host · $project"
+    body="${event:-event}"
+    tags="robot"
+    priority="3"
+    ;;
+esac
+
+curl -fsS \
+  -H "Title: $title" \
+  -H "Tags: $tags" \
+  -H "Priority: $priority" \
+  -d "$body" \
+  "https://ntfy.sh/$topic" >/dev/null 2>&1 || true
+
+exit 0

--- a/claude/.claude/settings.json
+++ b/claude/.claude/settings.json
@@ -45,6 +45,26 @@
           }
         ]
       }
+    ],
+    "Notification": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/notify-ntfy.sh"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/notify-ntfy.sh"
+          }
+        ]
+      }
     ]
   },
   "statusLine": {


### PR DESCRIPTION
## Summary
- New hook script `claude/.claude/hooks/notify-ntfy.sh` forwards Claude Code's `Notification` and `Stop` events to [ntfy.sh](https://ntfy.sh).
- Wires both events into `claude/.claude/settings.json`.
- Topic is read from `$NTFY_CLAUDE_TOPIC` (set in gitignored `~/.zshrc.local`), so the public repo never leaks the shared secret. Script no-ops silently if unset, so cloning the repo on a fresh machine is harmless.

The use case: when Claude is running on a remote VPS, it's hard to tell whether it's waiting for input or finished. This pushes a notification with project + hostname + reason directly to a phone (ntfy app) or a desktop PWA.

### Notification payload shape
- **Notification** event → priority 4 (pop-over), 🔔 tag, body uses Claude's actual message ("Claude needs your permission to use Bash" vs "waiting for your input").
- **Stop** event → priority 2 (silent, drawer-only), ✔️ tag, body "Turn complete". Quiet because Stop fires after every turn.

Title format: `Claude {waiting,done} · $hostname · $project` so multiple concurrent VPS sessions are distinguishable at a glance.

### Setup per machine
```bash
echo 'export NTFY_CLAUDE_TOPIC="claude-$(openssl rand -hex 8)"' >> ~/.zshrc.local
source ~/.zshrc.local && echo "$NTFY_CLAUDE_TOPIC"
# Subscribe to https://ntfy.sh/<that-topic> on phone or desktop
```

Requires `jq` (already installed everywhere I run this).

## Test plan
- [x] JSON in `settings.json` parses cleanly
- [x] Script exits 0 silently when `NTFY_CLAUDE_TOPIC` is unset
- [x] Script delivers a push when fed a synthetic `Notification` payload
- [x] Script delivers a push when fed a synthetic `Stop` payload
- [ ] End-to-end: Claude session triggers `Stop` hook on turn completion
- [ ] End-to-end: idle >60s triggers `Notification` hook
- [ ] End-to-end: permission prompt triggers `Notification` hook with the prompt text in body