### PR TITLE
Add deep link to claude.ai in ntfy notifications

### DIFF
--- a/claude/.claude/hooks/notify-ntfy.sh
+++ b/claude/.claude/hooks/notify-ntfy.sh
@@ -17,9 +17,19 @@ extract() {
 event=$(extract hook_event_name)
 message=$(extract message)
 cwd=$(extract cwd)
+session_id=$(extract session_id)
 
 project=$(basename "${cwd:-claude}")
 host=$(hostname -s 2>/dev/null || echo claude)
+
+click_url=""
+if [ -n "$session_id" ]; then
+  bridge_id=$(jq -r --arg s "$session_id" \
+    'select(.sessionId == $s) | .bridgeSessionId // empty' \
+    /home/natsumi/.claude/sessions/*.json 2>/dev/null \
+    | grep -m1 '^session_')
+  [ -n "$bridge_id" ] && click_url="https://claude.ai/code/$bridge_id"
+fi
 
 case "$event" in
   Notification)
@@ -42,10 +52,14 @@ case "$event" in
     ;;
 esac
 
+click_header=()
+[ -n "$click_url" ] && click_header=(-H "Click: $click_url")
+
 curl -fsS \
   -H "Title: $title" \
   -H "Tags: $tags" \
   -H "Priority: $priority" \
+  "${click_header[@]}" \
   -d "$body" \
   "https://ntfy.sh/$topic" >/dev/null 2>&1 || true
 

--- a/claude/.claude/hooks/notify-ntfy.sh
+++ b/claude/.claude/hooks/notify-ntfy.sh
@@ -26,7 +26,7 @@ click_url=""
 if [ -n "$session_id" ]; then
   bridge_id=$(jq -r --arg s "$session_id" \
     'select(.sessionId == $s) | .bridgeSessionId // empty' \
-    /home/natsumi/.claude/sessions/*.json 2>/dev/null \
+    "$HOME"/.claude/sessions/*.json 2>/dev/null \
     | grep -m1 '^session_')
   [ -n "$bridge_id" ] && click_url="https://claude.ai/code/$bridge_id"
 fi

--- a/claude/.claude/hooks/notify-ntfy.sh
+++ b/claude/.claude/hooks/notify-ntfy.sh
@@ -18,9 +18,23 @@ event=$(extract hook_event_name)
 message=$(extract message)
 cwd=$(extract cwd)
 session_id=$(extract session_id)
+transcript_path=$(extract transcript_path)
 
 project=$(basename "${cwd:-claude}")
 host=$(hostname -s 2>/dev/null || echo claude)
+
+last_assistant_text() {
+  [ -f "$transcript_path" ] || return
+  jq -nr '
+    reduce inputs as $e (null;
+      if $e.type == "assistant"
+        and any($e.message.content[]?; .type == "text")
+      then $e else . end)
+    | (.message.content // [])
+    | map(select(.type == "text") | .text)
+    | join(" ")
+  ' "$transcript_path" 2>/dev/null | tr -s '[:space:]' ' ' | head -c 200
+}
 
 click_url=""
 if [ -n "$session_id" ]; then
@@ -35,12 +49,15 @@ case "$event" in
   Notification)
     title="Claude waiting · $host · $project"
     body="${message:-Waiting for input}"
+    preview=$(last_assistant_text)
+    [ -n "$preview" ] && body="$body — $preview"
     tags="bell"
     priority="4"
     ;;
   Stop)
     title="Claude done · $host · $project"
-    body="Turn complete"
+    body="$(last_assistant_text)"
+    body="${body:-Turn complete}"
     tags="heavy_check_mark"
     priority="2"
     ;;


### PR DESCRIPTION
## Summary
- Adds a `Click:` header to ntfy posts so tapping the iOS notification opens `https://claude.ai/code/<bridgeSessionId>` and lands on the originating Claude Code session.
- Resolves the hook payload's `session_id` (UUID) to the ULID-style `bridgeSessionId` via `~/.claude/sessions/<pid>.json` — these files are present when `/remote-control` is active for the session.
- Silently skips the Click header when no matching session file exists (so non-remote-control sessions still notify normally).

## Test plan
- [x] Piped a fake `Notification` payload matching this session into the hook — lookup resolved and curl included the `Click:` header.
- [x] Tapped the resulting notification on iPhone — opened the Claude app on the correct session.
- [ ] Smoke test on a non-remote-control session: notification still arrives, no Click header.