### PR TITLE
Fix guard-main-branch.sh to actually block edits on main

### DIFF
--- a/claude/.claude/hooks/guard-main-branch.sh
+++ b/claude/.claude/hooks/guard-main-branch.sh
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
 
-# Guard hook: block file edits on the main/master branch.
-# Allows edits in linked worktrees or on any non-main branch.
-# Allows edits outside of git repos.
+# Guard hook: block file edits and mutating Bash commands on main/master.
+# Allows operations in linked worktrees, on non-main branches, or outside git.
 #
 # The decision is keyed on the *target file's* repository and branch
 # (read from tool_input.file_path / tool_input.notebook_path on stdin),
@@ -10,31 +9,50 @@
 # cwd is the harness root even when they're editing a file inside a
 # linked worktree, so a cwd-based check would block edits the user
 # clearly intends to allow.
+#
+# For Bash, there's no file_path to key on, so we fall back to the hook's
+# cwd. Most Bash invocations are read-only and exit fast (no git calls).
 
 payload=$(cat)
-file=$(printf '%s' "$payload" | jq -r '.tool_input.file_path // .tool_input.notebook_path // empty')
+tool=$(printf '%s' "$payload" | jq -r '.tool_name // empty')
 
-# No path in the payload? Fall back to the hook's own cwd.
-if [ -z "$file" ]; then
-  target_dir="."
-else
-  # The file may not exist yet (Write creating a new file). Walk up to
-  # the first directory that does exist so `git -C` has something real.
-  target_dir=$(dirname -- "$file")
-  while [ ! -d "$target_dir" ] && [ "$target_dir" != "/" ] && [ "$target_dir" != "." ]; do
-    target_dir=$(dirname -- "$target_dir")
-  done
-fi
+case "$tool" in
+  Bash)
+    cmd=$(printf '%s' "$payload" | jq -r '.tool_input.command // empty')
+    # Cheap early-exit: only proceed for known-mutating commands.
+    case "$cmd" in
+      *"git commit"*|*"git merge"*|*"git rebase"*|*"git reset --hard"*|\
+      *"git push"*|*"git am "*|*"git cherry-pick"*|*"git revert"*) ;;
+      *) exit 0 ;;
+    esac
+    target_dir="."
+    ;;
+  *)
+    file=$(printf '%s' "$payload" | jq -r '.tool_input.file_path // .tool_input.notebook_path // empty')
+    if [ -z "$file" ]; then
+      target_dir="."
+    else
+      # File may not exist yet (Write creating a new file). Walk up to
+      # the first directory that does exist so `git -C` has something real.
+      target_dir=$(dirname -- "$file")
+      while [ ! -d "$target_dir" ] && [ "$target_dir" != "/" ] && [ "$target_dir" != "." ]; do
+        target_dir=$(dirname -- "$target_dir")
+      done
+    fi
+    ;;
+esac
 
 # Not in a git repo? Allow.
 git -C "$target_dir" rev-parse --git-dir &>/dev/null || exit 0
 
-# Inside a linked worktree (git-dir differs from the common dir)? Allow.
+# Linked worktrees have a `commondir` file inside their git-dir pointing
+# back to the main repo's git-dir. Main checkouts do not.
 git_dir=$(git -C "$target_dir" rev-parse --git-dir)
-common_dir=$(git -C "$target_dir" rev-parse --git-common-dir)
-if [ "$git_dir" != "$common_dir" ]; then
-  exit 0
-fi
+case "$git_dir" in
+  /*) ;;
+  *) git_dir="$target_dir/$git_dir" ;;
+esac
+[ -f "$git_dir/commondir" ] && exit 0
 
 # On a non-main/master branch? Allow.
 branch=$(git -C "$target_dir" branch --show-current 2>/dev/null)
@@ -42,5 +60,9 @@ if [ -n "$branch" ] && [ "$branch" != "main" ] && [ "$branch" != "master" ]; the
   exit 0
 fi
 
-echo "Edits must be made in a branch or worktree, not on main/master." >&2
+if [ "$tool" = "Bash" ]; then
+  echo "Mutating Bash command blocked on $branch. Switch to a feature branch or worktree." >&2
+else
+  echo "Edits must be made in a branch or worktree, not on $branch." >&2
+fi
 exit 2

--- a/claude/.claude/settings.json
+++ b/claude/.claude/settings.json
@@ -37,7 +37,7 @@
   "hooks": {
     "PreToolUse": [
       {
-        "matcher": "Edit|Write|NotebookEdit",
+        "matcher": "Edit|Write|NotebookEdit|Bash",
         "hooks": [
           {
             "type": "command",


### PR DESCRIPTION
Closes #57.

## Summary

- Replace buggy worktree detection (string compare of `git-dir` vs `git-common-dir` — failed in subdirectories because one was absolute and the other relative) with a check for the `commondir` sentinel file every linked worktree's git-dir contains.
- Add `Bash` to the `PreToolUse` matcher with a fast early-exit allowlist so mutating commands like `git commit`, `git push`, `git rebase`, `git reset --hard`, `git cherry-pick`, `git revert`, `git am`, `git merge` are blocked on main while read-only commands skip all git work.

Overhead on the common (non-mutating) Bash path is ~11ms per call: one `jq` parse and a glob match, no git invocations.

## Test plan

Acceptance criteria from the issue, verified locally:

- [x] Edit on main in a subdirectory of the main repo → blocked (`exit=2`). Was `exit=0` before.
- [x] Edit on a feature branch in a linked worktree → allowed.
- [x] `git commit` on main → blocked.
- [x] `git status` on main → allowed (read-only, fast path).
- [x] `git commit` in a worktree on a non-main branch → allowed.
- [x] Edit outside any git repo → allowed.
- [x] Repro from issue (`echo '{"tool_input":{"file_path":"...subdir..."}}' | guard-main-branch.sh`) now exits 2 with the guard message.