### PR TITLE
fix(claude): guard empty click_header array in notify-ntfy hook

### DIFF
--- a/claude/.claude/hooks/notify-ntfy.sh
+++ b/claude/.claude/hooks/notify-ntfy.sh
@@ -76,7 +76,7 @@ curl -fsS \
   -H "Title: $title" \
   -H "Tags: $tags" \
   -H "Priority: $priority" \
-  "${click_header[@]}" \
+  ${click_header[@]+"${click_header[@]}"} \
   -d "$body" \
   "https://ntfy.sh/$topic" >/dev/null 2>&1 || true
 


### PR DESCRIPTION
## Problem

The `notify-ntfy.sh` Stop/Notification hook crashes with:

```
line 75: click_header[@]: unbound variable
```

## Root cause

`click_header` stays an empty array whenever a session has no `bridgeSessionId` (i.e. remote control / claude.ai bridge isn't active — a plain local terminal session). Under `set -u`, **bash 3.2** — the only bash macOS ships at `/bin/bash` — treats expanding an empty array as an unbound variable and aborts.

This branch has been latent since the deep-link feature (#56) was added: sessions driven from claude.ai always had a populated `bridgeSessionId`, so the empty-array path was never exercised until a purely local session fired the hook. The feature's own intent was to "silently skip the header when remote-control isn't active" — but the skip path itself was the crash.

## Fix

One line — use the empty-array-safe expansion so the skip branch is genuinely a no-op:

```bash
${click_header[@]+"${click_header[@]}"}
```

Verified under `bash 3.2` for both empty (no header) and populated (header passed) cases.

https://claude.ai/code/session_01Mi2unyEFK3uWeFTxLKUftk