### PR TITLE
fix(homebrew): make setup scripts compatible with Homebrew 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,27 @@ My very opinated configuration and setup scripts for new and existing Macs.
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/natsumi/dotfiles/main/bin/bootstrap.sh)"
 ```
 
+## Homebrew Taps
+
+Homebrew 6 will not load formulae, casks or external commands from non-official
+taps until they are explicitly trusted. The `trust_homebrew_taps` setup step
+runs `brew trust --tap` for every third-party tap used here before any packages
+are installed, and `homebrew/Brewfile` marks the same taps `trusted: true`.
+
+To trust a tap by hand:
+
+```bash
+brew trust --tap asmvik/formulae
+```
+
 ## Yabai Window Manager
 
-[Yabai Window Manager](https://github.com/koekeishiya/yabai)
+[Yabai Window Manager](https://github.com/asmvik/yabai)
 
-[Simple Keyboard Hot Keys](https://github.com/koekeishiya/skhd)
+[Simple Keyboard Hot Keys](https://github.com/asmvik/skhd)
+
+Both are installed from the `asmvik/formulae` tap, which is upstream's current
+home — the old `koekeishiya/*` URLs now redirect there.
 
 # Desktop Applications
 
@@ -82,7 +98,6 @@ These are tools that are installed via `brew bundle --file=homebrew/Brewfile`
 ## Utilities
 - [aria2](https://aria2.github.io/) - Lightweight multi-protocol download utility
 - [bat](https://github.com/sharkdp/bat) - Cat clone with syntax highlighting
-- [brew-cask-upgrade](https://github.com/buo/brew-cask-upgrade) - Command line tool for upgrading outdated Homebrew Casks
 - [broot](https://github.com/Canop/broot) - Better way to navigate directories
 - [croc](https://github.com/schollz/croc) - Easily and securely send things from one computer to another / Magic Wormhole
 - [eza](https://github.com/eza-community/eza) - Modern replacement for ls
@@ -103,8 +118,8 @@ These are tools that are installed via `brew bundle --file=homebrew/Brewfile`
 - [zsh](https://www.zsh.org/) - Extended Bourne shell with many improvements
 
 ## Desktop Managers
-- [skhd](https://github.com/koekeishiya/skhd) - Simple hotkey daemon for macOS
-- [yabai](https://github.com/koekeishiya/yabai) - Tiling window manager for macOS
+- [skhd](https://github.com/asmvik/skhd) - Simple hotkey daemon for macOS
+- [yabai](https://github.com/asmvik/yabai) - Tiling window manager for macOS
 
 # Default Language Packages
 

--- a/bin/bootstrap.sh
+++ b/bin/bootstrap.sh
@@ -20,6 +20,11 @@ readonly REPO_URL="https://github.com/natsumi/dotfiles"
 readonly REPO_BRANCH="${REPO_BRANCH:-main}"
 readonly DOTFILES_DIR="${DOTFILES_DIR:-$HOME/dev/dotfiles}"
 
+# Homebrew 6 prompts for confirmation before installing ("ask mode") whenever it
+# has a TTY. This script is meant to run unattended, and `set -e` would abort on
+# a declined prompt, so opt out for the whole run.
+export HOMEBREW_NO_ASK=1
+
 # Functions
 error_exit() {
     echo -e "${RED}ERROR: $1${NC}" >&2
@@ -108,7 +113,8 @@ install_ruby() {
     info "Installing latest Ruby via mise..."
 
     info "Installing build libraries..."
-    brew install jemalloc libffi libtool libxslt libyaml openssl readline unixodbc xz zlib
+    brew install jemalloc libffi libtool libxslt libyaml openssl readline unixodbc xz zlib \
+        || error_exit "Failed to install Ruby build libraries"
 
     info "Installing Ruby..."
     mise install ruby@latest || error_exit "Failed to install Ruby"

--- a/homebrew/Brewfile
+++ b/homebrew/Brewfile
@@ -39,6 +39,7 @@ brew 'shfmt'
 brew 'stylua'
 
 # Utitlies
+brew 'croc' # peer-to-peer file transfer
 brew 'ffmpeg'
 brew 'htop-osx'
 brew 'mas'

--- a/homebrew/Brewfile
+++ b/homebrew/Brewfile
@@ -1,6 +1,6 @@
-tap 'homebrew/bundle'
-tap 'neovim/neovim'
-tap 'buo/cask-upgrade'
+# Homebrew 6 requires non-official taps to be trusted before their formulae
+# are loaded. `trusted: true` is applied before anything is fetched.
+tap 'asmvik/formulae', trusted: true
 
 # Build Tools
 brew 'autoconf'
@@ -69,8 +69,8 @@ brew 'stow'
 brew 'fd'
 
 # Desktop Managers
-brew 'koekeishiya/formulae/skhd'
-brew 'yabai'
+brew 'asmvik/formulae/skhd'
+brew 'asmvik/formulae/yabai'
 
 # Fonts
 # Powerline Fonts

--- a/setup/config/step_order.yml
+++ b/setup/config/step_order.yml
@@ -1,6 +1,7 @@
 categories:
   - name: 'Package Management'
     steps:
+      - trust_homebrew_taps
       - install_homebrew_packages
 
   - name: 'Desktop Applications'

--- a/setup/lib/dotfiles/steps/install_desktop_apps.rb
+++ b/setup/lib/dotfiles/steps/install_desktop_apps.rb
@@ -24,7 +24,7 @@ module Dotfiles
             alfred
             forklift
             google-chrome
-            homebrew/cask-versions/firefox-developer-edition
+            firefox@developer-edition
             itsycal
             shottr
           ],

--- a/setup/lib/dotfiles/steps/install_homebrew_packages.rb
+++ b/setup/lib/dotfiles/steps/install_homebrew_packages.rb
@@ -7,6 +7,7 @@ module Dotfiles
     class InstallHomebrewPackages < BrewInstallStep
       name "install_homebrew_packages"
       description "Install Homebrew packages from Brewfile"
+      depends_on "trust_homebrew_taps"
 
       private
 
@@ -76,8 +77,8 @@ module Dotfiles
             zsh
           ],
           "Desktop Managers" => %w[
-            koekeishiya/formulae/skhd
-            yabai
+            asmvik/formulae/skhd
+            asmvik/formulae/yabai
           ]
         }
       end

--- a/setup/lib/dotfiles/steps/trust_homebrew_taps.rb
+++ b/setup/lib/dotfiles/steps/trust_homebrew_taps.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require_relative "../core/step"
+require_relative "../core/step_result"
+require "open3"
+
+module Dotfiles
+  module Steps
+    # Homebrew 6 refuses to load formulae, casks and external commands from
+    # non-official taps until they are explicitly trusted. Trust has to be
+    # granted before anything tries to install from those taps, so this runs
+    # ahead of install_homebrew_packages.
+    class TrustHomebrewTaps < Core::Step
+      name "trust_homebrew_taps"
+      description "Trust third-party Homebrew taps (required by Homebrew 6)"
+
+      TAPS = %w[
+        asmvik/formulae
+      ].freeze
+
+      private
+
+      def should_skip?
+        !brew_trust_available?
+      end
+
+      def perform_step
+        trusted = []
+        failed = []
+
+        TAPS.each do |tap|
+          puts "  Trusting #{tap}..."
+          _, stderr, status = Open3.capture3("brew trust --tap #{tap}")
+
+          if status.success?
+            trusted << tap
+          else
+            failed << {name: tap, error: stderr.strip}
+            puts "    ✗ Failed to trust #{tap}: #{stderr.lines.first&.strip}"
+          end
+        end
+
+        build_result(trusted, failed)
+      end
+
+      # `brew trust` only exists on Homebrew 6+; on older versions there is
+      # nothing to do and the step skips rather than failing the run.
+      def brew_trust_available?
+        _, _, status = Open3.capture3("brew trust --help")
+        status.success?
+      rescue
+        false
+      end
+
+      def build_result(trusted, failed)
+        if failed.empty?
+          Core::StepResult.success(
+            output: "Trusted #{trusted.size} taps:\n  #{trusted.join(", ")}",
+            step_name: @name,
+            context: {trusted: trusted}
+          )
+        else
+          Core::StepResult.failure(
+            error: failure_summary(failed),
+            output: "Trusted: #{trusted.size}, Failed: #{failed.size}",
+            step_name: @name,
+            context: {trusted: trusted, failed: failed}
+          )
+        end
+      end
+
+      def failure_summary(failed)
+        lines = ["Failed to trust #{failed.size} taps:"]
+        failed.each do |failure|
+          error_msg = failure[:error].lines.first&.strip || "Unknown error"
+          lines << "  #{failure[:name]}: #{error_msg}"
+        end
+        lines.join("\n")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Homebrew 6 requires non-official taps to be trusted before their formulae, casks and external commands are loaded, and turns on "ask mode" confirmation prompts whenever brew has a TTY. Several entries in these scripts also pointed at taps that have since been archived or moved.

## Tap trust

- New `trust_homebrew_taps` step runs `brew trust --tap` before anything installs. Trust must be granted *before* install, so it is ordered ahead of `install_homebrew_packages` and wired with `depends_on` so it also runs when that step is invoked alone from the menu. It skips cleanly on Homebrew 5, where `brew trust` does not exist.
- `homebrew/Brewfile` marks `asmvik/formulae` as `trusted: true`, which `brew bundle` applies before it fetches or loads any entry.

Note the correct command is `brew trust --tap`, not `brew tap --trust` — the latter appears in several blog posts about 6.0 but does not exist.

## yabai and skhd moved

`brew 'yabai'` was unqualified and no longer resolves: yabai is not in homebrew-core. Upstream also renamed from `koekeishiya` to `asmvik`, and `koekeishiya/yabai`, `koekeishiya/skhd` and `koekeishiya/homebrew-formulae` all 301-redirect there. Both are now installed from `asmvik/formulae`, matching the install command in the yabai wiki.

## Dead taps and casks

- `homebrew/bundle` now errors when tapped (`was deprecated. This tap is now empty`); bundle is built into brew.
- `neovim/neovim` is unnecessary — neovim is in homebrew-core.
- `buo/cask-upgrade` is superseded by native `brew upgrade --cask --greedy` / `--greedy-latest` / `--greedy-auto-updates`.
- `homebrew/cask-versions/firefox-developer-edition` pointed at an archived tap; the cask is now `firefox@developer-edition` in homebrew/cask. (Pre-existing breakage, not caused by Homebrew 6.)

## Ask mode

`bootstrap.sh` exports `HOMEBREW_NO_ASK=1` so a confirmation prompt cannot stall an unattended run — relevant because the documented invocation is `/bin/bash -c "$(curl …)"`, which keeps stdin attached to the terminal, and `set -e` would abort on a decline. The build-library install also now fails explicitly like the calls around it.

The Ruby steps did not need this: `brew` auto-disables ask mode without a TTY (`ask.rb:13`), and they all shell out via `Open3.capture3`.

## Verification

- `brew bundle check` against the new Brewfile: zero trust warnings, versus two before.
- `brew info` exits 0 for `asmvik/formulae/yabai`, `asmvik/formulae/skhd`, `firefox@developer-edition`.
- All 18 font cask tokens verified to still exist; that section needed no changes, since it never referenced the archived `homebrew/cask-fonts`.
- Step loader resolves `trust_homebrew_taps` first, with `install_homebrew_packages deps=["trust_homebrew_taps"]`.
- `ruby -c` clean on all steps; `bash -n bin/bootstrap.sh` passes.

Trust-granting behavior was tested against an isolated `XDG_CONFIG_HOME` rather than the real `trust.json`.

https://claude.ai/code/session_01MK2Q2VitfuwLST4AuQE8r6